### PR TITLE
Introduce AlphaInnotecApiError for clearer API failures

### DIFF
--- a/custom_components/alpha_innotec/api.py
+++ b/custom_components/alpha_innotec/api.py
@@ -11,6 +11,16 @@ from urllib3 import Retry
 _LOGGER = logging.getLogger(__name__)
 
 
+class AlphaInnotecApiError(Exception):
+    """Raised when the Alpha Innotec API returns an error."""
+
+    def __init__(self, message: str, endpoint: str | None = None) -> None:
+        if endpoint:
+            message = f"[{endpoint}] {message}"
+        super().__init__(message)
+        self.endpoint = endpoint
+
+
 class BaseAPI:
 
     def __init__(self, hostname: str, username: str, password: str) -> None:

--- a/custom_components/alpha_innotec/controller_api.py
+++ b/custom_components/alpha_innotec/controller_api.py
@@ -5,7 +5,7 @@ from urllib.parse import unquote
 
 import requests
 
-from .api import BaseAPI
+from .api import BaseAPI, AlphaInnotecApiError
 from .structs.Thermostat import Thermostat
 
 _LOGGER = logging.getLogger(__name__)
@@ -57,7 +57,8 @@ class ControllerAPI(BaseAPI):
         _LOGGER.debug("[%s] - response body: %s", endpoint, json_response)
 
         if not json_response['success']:
-            raise Exception('Failed to get data')
+            _LOGGER.error("[%s] - API response unsuccessful: %s", endpoint, json_response)
+            raise AlphaInnotecApiError("Failed to get data", endpoint)
         else:
             _LOGGER.debug('[%s] - successfully fetched data from API', endpoint)
 

--- a/custom_components/alpha_innotec/controller_api.py
+++ b/custom_components/alpha_innotec/controller_api.py
@@ -42,17 +42,19 @@ class ControllerAPI(BaseAPI):
 
             _LOGGER.debug("[%s] - body: %s", endpoint, urlencoded_body)
 
-            response = self.session.post("http://{hostname}/{endpoint}".format(hostname=self.api_host, endpoint=endpoint),
-                                     data=urlencoded_body,
-                                     headers={'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
-                                     )
+            response = self.session.post(
+                "http://{hostname}/{endpoint}".format(hostname=self.api_host, endpoint=endpoint),
+                data=urlencoded_body,
+                headers={'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
+            )
 
             self.request_count = self.request_count + 1
 
             _LOGGER.debug("[%s] - response code: %s", endpoint, response.status_code)
             json_response = response.json()
-        except Exception as exception:
-            _LOGGER.exception("Unable to fetch data from API: %s", exception)
+        except requests.exceptions.RequestException as exception:
+            _LOGGER.error("Unable to fetch data from API endpoint [%s]: %s", endpoint, exception)
+            raise
 
         _LOGGER.debug("[%s] - response body: %s", endpoint, json_response)
 

--- a/custom_components/alpha_innotec/coordinator.py
+++ b/custom_components/alpha_innotec/coordinator.py
@@ -1,11 +1,14 @@
 import logging
 from datetime import timedelta
 
+import requests
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from . import ControllerAPI, GatewayAPI
+from .api import AlphaInnotecApiError
 from .const import DOMAIN, MODULE_TYPE_SENSOR
 from .structs.Thermostat import Thermostat
 from .structs.Valve import Valve
@@ -30,9 +33,12 @@ class AlphaInnotecCoordinator(DataUpdateCoordinator):
         self.gateway_api = hass.data[DOMAIN][self.config_entry.entry_id]['gateway_api']
 
     async def _async_update_data(self) -> dict[str, list[Valve | Thermostat]]:
-        db_modules: dict = await self.hass.async_add_executor_job(self.gateway_api.db_modules)
-        all_modules: dict = await self.hass.async_add_executor_job(self.gateway_api.all_modules)
-        room_list: dict = await self.hass.async_add_executor_job(self.controller_api.room_list)
+        try:
+            db_modules: dict = await self.hass.async_add_executor_job(self.gateway_api.db_modules)
+            all_modules: dict = await self.hass.async_add_executor_job(self.gateway_api.all_modules)
+            room_list: dict = await self.hass.async_add_executor_job(self.controller_api.room_list)
+        except (AlphaInnotecApiError, requests.exceptions.RequestException) as err:
+            raise UpdateFailed(str(err)) from err
 
         thermostats: list[Thermostat] = []
         valves: list[Valve] = []

--- a/custom_components/alpha_innotec/gateway_api.py
+++ b/custom_components/alpha_innotec/gateway_api.py
@@ -51,18 +51,20 @@ class GatewayAPI(BaseAPI):
 
             _LOGGER.debug("[%s] - body: %s", endpoint, urlencoded_body)
 
-            response = self.session.post("http://{hostname}/{endpoint}".format(hostname=self.api_host, endpoint=endpoint),
-                                     data=urlencoded_body,
-                                     headers={'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
-                                     )
+            response = self.session.post(
+                "http://{hostname}/{endpoint}".format(hostname=self.api_host, endpoint=endpoint),
+                data=urlencoded_body,
+                headers={'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'}
+            )
 
             self.request_count = self.request_count + 1
 
             _LOGGER.debug("[%s] - response code: %s", endpoint, response.status_code)
 
             json_response = response.json()
-        except Exception as exception:
-            _LOGGER.exception("Unable to fetch data from API: %s", exception)
+        except requests.exceptions.RequestException as exception:
+            _LOGGER.error("Unable to fetch data from API endpoint [%s]: %s", endpoint, exception)
+            raise
 
         _LOGGER.debug("[%s] - response body: %s", endpoint, json_response)
 

--- a/custom_components/alpha_innotec/gateway_api.py
+++ b/custom_components/alpha_innotec/gateway_api.py
@@ -5,7 +5,7 @@ from urllib.parse import unquote
 
 import requests
 
-from .api import BaseAPI
+from .api import BaseAPI, AlphaInnotecApiError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -67,7 +67,8 @@ class GatewayAPI(BaseAPI):
         _LOGGER.debug("[%s] - response body: %s", endpoint, json_response)
 
         if not json_response['success']:
-            raise Exception('Failed to get data')
+            _LOGGER.error("[%s] - API response unsuccessful: %s", endpoint, json_response)
+            raise AlphaInnotecApiError("Failed to get data", endpoint)
         else:
             _LOGGER.debug('[%s] - successfully fetched data from API', endpoint)
 


### PR DESCRIPTION
## Summary
- add `AlphaInnotecApiError` to centralize API error handling
- raise `AlphaInnotecApiError` instead of generic `Exception` in gateway and controller APIs
- log endpoint and response when API calls fail

## Testing
- `pip install -r requirements-test.txt` *(failed: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_68a6b34a195c832b8288104283da99c0