### PR TITLE
Attempt re-login on API errors

### DIFF
--- a/custom_components/alpha_innotec/controller_api.py
+++ b/custom_components/alpha_innotec/controller_api.py
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 
 class ControllerAPI(BaseAPI):
 
-    def call(self, endpoint: str, data: dict = None) -> dict:
+    def _call(self, endpoint: str, data: dict | None = None) -> dict:
         if data is None:
             data = {}
 
@@ -66,6 +66,14 @@ class ControllerAPI(BaseAPI):
 
         return json_response
 
+    def call(self, endpoint: str, data: dict | None = None) -> dict:
+        try:
+            return self._call(endpoint, data)
+        except (AlphaInnotecApiError, requests.exceptions.RequestException) as err:
+            _LOGGER.warning("Error calling controller API: %s, trying to re-login", err)
+            self.login()
+            return self._call(endpoint, data)
+
     def login(self):
         response = self.session.post("http://" + self.api_host + "/api/user/token/challenge", data={
             "udid": self.udid
@@ -93,7 +101,7 @@ class ControllerAPI(BaseAPI):
 
         self.device_token_decrypted = self.decrypt2(response.json()['devicetoken_encrypted'], self.password)
 
-        response = self.call("admin/login/check")
+        response = self._call("admin/login/check")
 
         if not response['success']:
             raise Exception("Unable to login")

--- a/custom_components/alpha_innotec/coordinator.py
+++ b/custom_components/alpha_innotec/coordinator.py
@@ -33,10 +33,15 @@ class AlphaInnotecCoordinator(DataUpdateCoordinator):
         self.gateway_api = hass.data[DOMAIN][self.config_entry.entry_id]['gateway_api']
 
     async def _async_update_data(self) -> dict[str, list[Valve | Thermostat]]:
-        try:
+        async def _fetch() -> tuple[dict, dict, dict]:
             db_modules: dict = await self.hass.async_add_executor_job(self.gateway_api.db_modules)
             all_modules: dict = await self.hass.async_add_executor_job(self.gateway_api.all_modules)
             room_list: dict = await self.hass.async_add_executor_job(self.controller_api.room_list)
+
+            return db_modules, all_modules, room_list
+
+        try:
+            db_modules, all_modules, room_list = await _fetch()
         except (AlphaInnotecApiError, requests.exceptions.RequestException) as err:
             raise UpdateFailed(str(err)) from err
 

--- a/custom_components/alpha_innotec/gateway_api.py
+++ b/custom_components/alpha_innotec/gateway_api.py
@@ -22,7 +22,7 @@ class GatewayAPI(BaseAPI):
         self.last_request_signature: str | None = None
         self.udid: str = "homeassistant"
 
-    def call(self, endpoint: str, data: dict = None) -> dict:
+    def _call(self, endpoint: str, data: dict | None = None) -> dict:
         if data is None:
             data = {}
 
@@ -76,8 +76,16 @@ class GatewayAPI(BaseAPI):
 
         return json_response
 
+    def call(self, endpoint: str, data: dict | None = None) -> dict:
+        try:
+            return self._call(endpoint, data)
+        except (AlphaInnotecApiError, requests.exceptions.RequestException) as err:
+            _LOGGER.warning("Error calling gateway API: %s, trying to re-login", err)
+            self.login()
+            return self._call(endpoint, data)
+
     def login(self):
-        response = self.call("admin/login/check")
+        response = self._call("admin/login/check")
 
         if not response['success']:
             raise Exception("Unable to login")


### PR DESCRIPTION
## Summary
- retry Alpha Innotec API authentication when data fetch fails
- retry Controller and Gateway API calls after authentication errors to handle reconnects gracefully

## Testing
- `pip install -r requirements-test.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_68a949beab30832bb05e259ac443bd9d